### PR TITLE
Update to JDK25 (and some minor fixes)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,7 @@ updates:
       - "/"
     schedule:
       interval: weekly
-    labels:
-      - "dependencies"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: weekly
-    labels:
-      - "dependencies"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,8 @@ name: Build
 
 on:
   push:
+    branches:
+      main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '24'
+          java-version: 25
           distribution: 'semeru'
           check-latest: true
       - name: Setup Gradle

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Demonstration of [Semeru-Runtimes#3](https://github.com/ibmruntimes/Semeru-Runtimes/issues/3)
 
-When executing `./gradlew jlinkZip` on macOS one gets
+For IBM Semeru releases before mid of Octoboer 2025, when executing `./gradlew jlinkZip` on macOS one gets
 
     java.lang.module.FindException: Hash of java.rmi (03f539ebf91c81cfc7a81236d2c1109e0d050c839d03c6f757022b99a10cb819) differs to expected hash (07126a5cefcc6c19d9059cfa4b42ec832f3714a1ef89f103afc2d1ab61b79bc7) recorded in java.base
+
+This is resolved for JDK 25.
 
 See also the build output of the workflow <https://github.com/koppor/openj9-hash-issue/actions/workflows/build.yaml>.

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'org.beryx.jlink' version '3.1.2'
+    id 'org.beryx.jlink' version '3.1.3'
 }
 
 repositories {
@@ -12,7 +12,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(24)
+        languageVersion = JavaLanguageVersion.of(25)
         vendor = JvmVendorSpec.IBM
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,0 @@
-plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
-}
-
-rootProject.name = 'openj9-hash-issue'

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+  id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
+rootProject.name = "openj9-hash-issue"


### PR DESCRIPTION
The JDK25 binary is from October (see https://github.com/AdoptOpenJDK/semeru25-binaries). Thus, https://github.com/ibmruntimes/Semeru-Runtimes/issues/3 seems to be fixed. Let's try.